### PR TITLE
指定maven默认编译版本为JDK 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,14 @@
     <artifactId>itstack-demo-design</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
+    </properties>
+
     <modules>
         <module>itstack-demo-design-1-01</module>
         <module>itstack-demo-design-1-00</module>


### PR DESCRIPTION
指定maven默认编译版本为JDK 1.8，避免导入到IDE时报“java: 错误: 不支持发行版本 5”错误