### PR TITLE
Could org.itstack:itstack-demo-design:1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/itstack-demo-design-18-00/pom.xml
+++ b/itstack-demo-design-18-00/pom.xml
@@ -11,5 +11,25 @@
 
     <artifactId>itstack-demo-design-18-00</artifactId>
 
-
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+         
 </project>

--- a/itstack-demo-design-20-01/pom.xml
+++ b/itstack-demo-design-20-01/pom.xml
@@ -10,6 +10,26 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>itstack-demo-design-20-01</artifactId>
-
+         
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/itstack-demo-design-3-00/pom.xml
+++ b/itstack-demo-design-3-00/pom.xml
@@ -11,5 +11,25 @@
 
     <artifactId>itstack-demo-design-3-00</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/itstack-demo-design-4-00/pom.xml
+++ b/itstack-demo-design-4-00/pom.xml
@@ -11,5 +11,25 @@
 
     <artifactId>itstack-demo-design-4-00</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/itstack-demo-design-9-00/pom.xml
+++ b/itstack-demo-design-9-00/pom.xml
@@ -11,5 +11,25 @@
 
     <artifactId>itstack-demo-design-9-00</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163909467-615e697f-5048-4edd-9348-e34faaaf18d8.png)
This figure presents the dependency tree between multiple modules in **_itstack-demo-design_**. As shown in this figure, Library
##
ch.qos.logback:logback-core:jar:1.0.9:compile
org.slf4j:jcl-over-slf4j:jar:1.7.5:compile
ch.qos.logback:logback-classic:jar:1.0.9:compile

---
in **_<module>itstack-demo-design-1-01</module>
        <module>itstack-demo-design-1-00</module>
        <module>itstack-demo-design-1-02</module>
        <module>itstack-demo-design-2-00</module>
        <module>itstack-demo-design-2-01</module>
        <module>itstack-demo-design-2-02</module>
        <module>itstack-demo-design-3-00</module>
        <module>itstack-demo-design-3-01</module>
        <module>itstack-demo-design-3-02</module>
        <module>itstack-demo-design-4-00</module>
        <module>itstack-demo-design-4-01</module>
        <module>itstack-demo-design-4-02</module>
        <module>itstack-demo-design-5-00</module>
        <module>itstack-demo-design-6-00</module>
        <module>itstack-demo-design-6-01</module>
        <module>itstack-demo-design-6-02</module>
        <module>itstack-demo-design-7-01</module>
        <module>itstack-demo-design-7-02</module>
        <module>itstack-demo-design-8-01</module>
        <module>itstack-demo-design-8-02</module>
        <module>itstack-demo-design-9-00</module>
        <module>itstack-demo-design-9-01</module>
        <module>itstack-demo-design-9-02</module>
        <module>itstack-demo-design-10-00</module>
        <module>itstack-demo-design-10-01</module>
        <module>itstack-demo-design-10-02</module>
        <module>itstack-demo-design-11-02</module>
        <module>itstack-demo-design-11-01</module>
        <module>itstack-demo-design-12-00</module>
        <module>itstack-demo-design-13-00</module>
        <module>itstack-demo-design-13-01</module>
        <module>itstack-demo-design-13-02</module>
        <module>itstack-demo-design-14-00</module>
        <module>itstack-demo-design-14-01</module>
        <module>itstack-demo-design-14-02</module>
        <module>itstack-demo-design-15-00</module>
        <module>itstack-demo-design-16-01</module>
        <module>itstack-demo-design-16-02</module>
        <module>itstack-demo-design-17-00</module>
        <module>itstack-demo-design-18-00</module>
        <module>itstack-demo-design-18-01</module>
        <module>itstack-demo-design-18-02</module>
        <module>itstack-demo-design-19-00</module>
        <module>itstack-demo-design-19-01</module>
        <module>itstack-demo-design-19-02</module>
        <module>itstack-demo-design-20-01</module>
        <module>itstack-demo-design-20-02</module>
        <module>itstack-demo-design-21-00</module>
        <module>itstack-demo-design-22-00</module>_**

 is inherited from their parent module. However, it is not used by **_itstack-demo-design-18-00, itstack-demo-design-20-01, itstack-demo-design-3-00, itstack-demo-design-4-00, itstack-demo-design-9-00_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_itstack-demo-design-18-00, itstack-demo-design-20-01, itstack-demo-design-3-00, itstack-demo-design-4-00, itstack-demo-design-9-00_**.

Specifically, the scope of **_org.slf4j:jcl-over-slf4j, ch.qos.logback:logback-classic_** in **_itstack-demo-design-18-00, itstack-demo-design-20-01, itstack-demo-design-3-00, itstack-demo-design-4-00, itstack-demo-design-9-00_** can be changed from compile to provided. The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/163910470-41502987-7f49-4e05-9332-a4d5cc6daf04.png)


Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_ch.qos.logback:logback-core:jar:1.0.9:compile_** incorporates a medium-level vulnerability SNYK-JAVA-CHQOSLOGBACK-1726923. 